### PR TITLE
remove ambiguity in rule description - vote stack unlock

### DIFF
--- a/system/council/README.md
+++ b/system/council/README.md
@@ -139,7 +139,7 @@ Unlocking the voting lock on the staking account requires an active recovery act
 
 * If the vote is for an ongoing election, then it is not recoverable.
 * If the vote is for the last concluded election, then it is recoverable only if it was unsealed in favor of a losing candidate, otherwise it is not.
-* If the vote is for any election before the last concluded, the it is always recoverable.
+* If the vote is for any prior election cycle, then it is always recoverable.
 
 ### Election
 


### PR DESCRIPTION
Update the description of the rule for vote stake unlocking to make it clearer.
Ref: https://github.com/Joystream/joystream/pull/3783